### PR TITLE
Center logo

### DIFF
--- a/gaplogo-pic.tex
+++ b/gaplogo-pic.tex
@@ -4,11 +4,6 @@
   \coordinate (C) at (240:\radius) {};
   \coordinate (Z) at (0,0) {};
 
-  % Coordinates for helping draw bounding box
-  \coordinate (INVISIBLEAN) at ( 90:\radius) {};
-  \coordinate (INVISIBLEAE) at (180:\radius) {};
-  \coordinate (INVISIBLEAS) at (270:\radius) {};
-
   \coordinate (AB1) at ( 50:\radius*1.2) {};
   \coordinate (AB2) at ( 70:\radius*1.2) {};
   \coordinate (BC1) at (170:\radius*1.2) {};
@@ -28,10 +23,6 @@
   \path[dynkinnodeB] (B) circle[radius=\noderadius];
   \path[dynkinnodeC] (C) circle[radius=\noderadius];
 
-  % Invisible nodes for bounding box
-  \path[dynkinnodeA, draw=none, fill=none] (INVISIBLEAS) circle[radius=\noderadius];
-  \path[dynkinnodeA, draw=none, fill=none] (INVISIBLEAN) circle[radius=\noderadius];
-  \path[dynkinnodeA, draw=none, fill=none] (INVISIBLEAE) circle[radius=\noderadius];
 
   % draw the three double-ended arrows which indicate swapping of the circles
   % for this we use circle arcs but with slightly reduced radius
@@ -43,6 +34,16 @@
 
 \draw[<->, dynkinarrowCA] ({240+\margin}:\radiusB)
   arc ({240+\margin}:{360-\margin}:\radiusB);
+
+
+  % Invisible circle to make bounding box centered on (0, 0)
+  \draw[draw=none, fill=none] let
+    \p1 = ($(current bounding box.east)$), \n1 = {veclen(\x1,\y1)},
+    \p2 = ($(current bounding box.west)$), \n2 = {veclen(\x2,\y2)},
+    \p3 = ($(current bounding box.south)$), \n3 = {veclen(\x3,\y3)},
+    \p4 = ($(current bounding box.north)$), \n4 = {veclen(\x4,\y4)},
+    \n5={max(\n1, \n2, \n3, \n4)}
+    in (0, 0) circle (\n5);
 
 
 \ifx\NoTextMode\undefined

--- a/gaplogo.sty
+++ b/gaplogo.sty
@@ -22,6 +22,7 @@
   \usetikzlibrary{bending}
   \usetikzlibrary{shadows}
   \usetikzlibrary{arrows.meta}
+  \usetikzlibrary{calc}
 
 
 \def\DarkTheme{dark}


### PR DESCRIPTION
This PR offers a fix for part of https://github.com/gap-system/gap/issues/6107 . In particular, it modifies the bounding box of the logo so that the standalone square logos center is in the middle of the picture. Picture of initial issue and comparison of fixes below (gray circle drawn across the background for comparison):

| The issue | Fix 1 (repeated node) | Fix 2 (bounding circle) |
| -------------------- | ------------------------------- | ------------------------------- |
| <img width="256" height="256" alt="issue" src="https://github.com/user-attachments/assets/70b45e91-9dd8-4953-803f-83abe891daae" /> | <img width="256" height="256" alt="issue-fix1" src="https://github.com/user-attachments/assets/5d226186-a040-43c4-addd-14e5848bb388" /> | <img width="256" height="256" alt="issue-fix2" src="https://github.com/user-attachments/assets/fa88a9f5-9ca3-4578-a85a-3635d774b729" /> |

Two fixes were attempted: In fix 1, the green node A was drawn invisible in the north, south and west directions. This improved the situation somewhat (see Fix 1 picture above), but there were still some issues with the logo clipping out of the bounding circle, which was pretty strange.

Fix 2, which is what I'm proposing for this PR calculates the maximum bounding box dimension of the original logo picture using a tikz incantation and then draws an invisible bounding circle using this dimension as the radius. The result (see Fix 2 picture above) looks much better (still some artefacts due to the svg to png conversion) and the approach is more general in case the logo changes or gets rotated.