### PR TITLE
Rotate logo

### DIFF
--- a/gaplogo-pic.tex
+++ b/gaplogo-pic.tex
@@ -1,16 +1,8 @@
   % set coordinates of the four circles, starting at the one on the right
-  \coordinate (A) at (  0:\radius) {};
-  \coordinate (B) at (120:\radius) {};
-  \coordinate (C) at (240:\radius) {};
+  \coordinate (A) at (    \rotationangle:\radius) {};
+  \coordinate (B) at (120+\rotationangle:\radius) {};
+  \coordinate (C) at (240+\rotationangle:\radius) {};
   \coordinate (Z) at (0,0) {};
-
-  \coordinate (AB1) at ( 50:\radius*1.2) {};
-  \coordinate (AB2) at ( 70:\radius*1.2) {};
-  \coordinate (BC1) at (170:\radius*1.2) {};
-  \coordinate (BC2) at (190:\radius*1.2) {};
-  \coordinate (CA1) at (290:\radius*1.2) {};
-  \coordinate (CA2) at (310:\radius*1.2) {};
-
 
   % draw the edges connecting the four circles / nodes
   \draw[shorten >= 2mm, shorten <=2mm, dynkinedgeA] (Z) -- (A);
@@ -25,14 +17,14 @@
 
   % draw the three double-ended arrows which indicate swapping of the circles
   % for this we use circle arcs but with slightly reduced radius
-\draw[<->, dynkinarrowAB] ({0+\margin}:\radiusB)
-  arc ({0+\margin}:{120-\margin}:\radiusB);
+\draw[<->, dynkinarrowAB] ({\rotationangle+\margin}:\radiusB)
+  arc ({\rotationangle+\margin}:{120+\rotationangle-\margin}:\radiusB);
 
-\draw[<->, dynkinarrowBC] ({120+\margin}:\radiusB)
-  arc ({120+\margin}:{240-\margin}:\radiusB);
+\draw[<->, dynkinarrowBC] ({120+\rotationangle+\margin}:\radiusB)
+  arc ({120+\rotationangle+\margin}:{240+\rotationangle-\margin}:\radiusB);
 
-\draw[<->, dynkinarrowCA] ({240+\margin}:\radiusB)
-  arc ({240+\margin}:{360-\margin}:\radiusB);
+\draw[<->, dynkinarrowCA] ({240+\rotationangle+\margin}:\radiusB)
+  arc ({240+\rotationangle+\margin}:{360+\rotationangle-\margin}:\radiusB);
 
 
 \ifx\NoTextMode\undefined

--- a/gaplogo.sty
+++ b/gaplogo.sty
@@ -90,3 +90,4 @@
 \def\radius {10mm}  % radius for placement of the three outer nodes
 \def\radiusB {9mm}  % radius for the arrows (drawn as circle arcs)
 \def\noderadius {2.2mm}
+\def\rotationangle {15}

--- a/gaplogo.sty
+++ b/gaplogo.sty
@@ -90,4 +90,4 @@
 \def\radius {10mm}  % radius for placement of the three outer nodes
 \def\radiusB {9mm}  % radius for the arrows (drawn as circle arcs)
 \def\noderadius {2.2mm}
-\def\rotationangle {15}
+\def\rotationangle {0}


### PR DESCRIPTION
This PR adds a rotation angle parameter to the logo `.sty` file, addressing part of https://github.com/gap-system/gap/issues/6107. Additionally, some unused coordinates are also cleaned up. Below are some pictures of various rotation angles (note that these images were generated without #1 and so may look a bit off-center):

| Angle | 0 | 15 | 30 | 45 | 180 |
| - | - | - | - | - | - |
| Image | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/99b519db-e444-40b7-93c9-ecddd44b1d50" /> | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/d54de868-1a25-4c0f-8382-7f7f5917878c" /> | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/04d77298-6fb2-40b2-87f5-3db5d2fa55b4" /> | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/1a520a8e-c0f2-42f2-82fb-486ee59a078c" /> | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/226da33a-50a3-4275-89b6-1742966136b5" /> |



