### PR TITLE
Mirror logo

### DIFF
--- a/gaplogo-pic.tex
+++ b/gaplogo-pic.tex
@@ -1,7 +1,12 @@
   % set coordinates of the four circles, starting at the one on the right
   \coordinate (A) at (    \rotationangle:\radius) {};
+\ifx\mirrored\undefined
   \coordinate (B) at (120+\rotationangle:\radius) {};
   \coordinate (C) at (240+\rotationangle:\radius) {};
+\else
+  \coordinate (B) at (240+\rotationangle:\radius) {};
+  \coordinate (C) at (120+\rotationangle:\radius) {};
+\fi
   \coordinate (Z) at (0,0) {};
 
   % draw the edges connecting the four circles / nodes

--- a/gaplogo.sty
+++ b/gaplogo.sty
@@ -92,3 +92,5 @@
 \def\radiusB {9mm}  % radius for the arrows (drawn as circle arcs)
 \def\noderadius {2.2mm}
 \def\rotationangle {0}
+% Uncomment the following line to mirror logo along the line through node Z (the center) and A.
+%\def\mirrored {} % Equivalent to swapping the nodes B and C


### PR DESCRIPTION
This PR adds a configuration option in the `gaplogo.sty` file which allows for mirroring the logo along the ling through the nodes `Z` (the center of the logo) and `A` (the green node in the light color version. This is equivalent to swapping the nodes `B` and `C` (the blue and yellow nodes in the light color version). To enable mirroring, simply uncomment the `\def\mirrored {}` line in the style file (or otherwise define a `\mirrored` command). This addresses one part of https://github.com/gap-system/gap/issues/6107 . With this we can now apply any possible symmetry of the logo via config options in the `gaplogo.sty` file.

Below is a selection of some rotated logos along with their mirrored counterparts (below):

| | No rotation | Rotated 180 degrees | Rotated 15 degrees |
| - | - | - | - | 
| **Original** | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/23657c57-3062-464a-8c88-a435c175e162" /> |  <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/0baf54c0-9443-48a0-ad1f-6f6cde4fc83f" /> | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/72874345-cfb4-416b-86ec-22ee6740a64c" /> |
| **Mirrored** | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/64271fca-c220-492d-9522-8ac93d3ea5ee" /> | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/8be9d42f-82aa-40da-8da2-342f7f8fc375" /> | <img width="256" height="256" alt="gaplogo-notext" src="https://github.com/user-attachments/assets/52cfed31-c15a-42ee-80ba-539254c82a62" /> |

